### PR TITLE
bugfix/accurics_remediation_9842505429307358 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,10 @@ resource "aws_s3_bucket" "accuricsbucketdemo" {
   bucket = "my-tf-test-bucket"
 
   tags = {
-    Name        = "bucketdemo"
+    Name = "bucketdemo"
+  }
+
+  logging {
+    target_bucket = "<target_bucket_name>"
   }
 }


### PR DESCRIPTION
By default, Amazon S3 doesn't collect server access logs. When you enable logging, Amazon S3 delivers access logs for a source bucket to a target bucket that you choose. The target bucket must be in the same AWS Region as the source bucket and must not have a default retention period configuration.