### PR TITLE
bugfix/accurics_remediation_35024557481187446 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,32 @@ resource "aws_s3_bucket" "accuricsbucketdemo" {
   bucket = "my-tf-test-bucket"
 
   tags = {
-    Name        = "bucketdemo"
+    Name = "bucketdemo"
   }
+}
+
+resource "aws_s3_bucket_policy" "accuricsbucketdemoPolicy" {
+  bucket = "${aws_s3_bucket.accuricsbucketdemo.id}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "accuricsbucketdemo-restrict-access-to-users-or-roles",
+      "Effect": "Allow",
+      "Principal": [
+        {
+          "AWS": [
+            "arn:aws:iam::##acount_id##:role/##role_name##",
+            "arn:aws:iam::##acount_id##:user/##user_name##"
+          ]
+        }
+      ],
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.accuricsbucketdemo.id}/*"
+    }
+  ]
+}
+POLICY
 }


### PR DESCRIPTION
Amazon S3 Bucket ACL with full control permission to authenticated users allows anyone with an AWS account to access objects in the bucket. When read and write access is granted to authenticated users, they can read, edit and delete the objects in the bucket. It is a recommended practice to remove full control permission from S3 Bucket ACL.